### PR TITLE
add behavior tests for allowed_users decorator

### DIFF
--- a/tests/behavior_tests/run_bot.py
+++ b/tests/behavior_tests/run_bot.py
@@ -2,6 +2,7 @@
 from mmpy_bot.bot import Bot, PluginsManager
 from mmpy_bot.mattermost import MattermostClient
 from mmpy_bot.dispatcher import MessageDispatcher
+from mmpy_bot import settings
 import bot_settings
 
 
@@ -14,6 +15,7 @@ class LocalBot(Bot):
             bot_settings.SSL_VERIFY
         )
         self._plugins = PluginsManager()
+        self._plugins.plugins = bot_settings.PLUGINS
         self._plugins.init_plugins()
         self._dispatcher = MessageDispatcher(self._client, self._plugins)
 

--- a/tests/behavior_tests/test_behaviors.py
+++ b/tests/behavior_tests/test_behaviors.py
@@ -108,3 +108,14 @@ def test_bot_create_get_list_post_delete_webhook(driver):
         raise AssertionError('something wrong, the hook {} should be found.'.format(created))
     # test send post through webhook
     driver.send_post_webhook(created['id'])
+
+
+def test_allowed_users(driver):
+    driver.send_channel_message('allowed_driver', tobot=True)
+    driver.wait_for_bot_channel_message('Driver allowed!', tosender=True)
+    driver.send_channel_message('not_allowed_driver', tobot=True)
+    try:
+        driver.wait_for_bot_channel_message('Driver not allowed!', tosender=True)
+        raise AssertionError('response "Hello not allowed!" was not expected.')
+    except AssertionError:
+        pass

--- a/tests/behavior_tests/test_plugins/test_access.py
+++ b/tests/behavior_tests/test_plugins/test_access.py
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+
+from mmpy_bot.utils import allowed_users
+from mmpy_bot.bot import respond_to, listen_to
+
+import sys
+import os
+sys.path.append(os.getcwd()) # enable importing driver_settings
+
+from tests.behavior_tests import driver_settings
+
+
+@respond_to('^allowed_driver$')
+@allowed_users(driver_settings.BOT_NAME)
+def driver_allowed_hello(message):
+    message.reply('Driver allowed!')
+
+
+@respond_to('^not_allowed_driver$')
+@allowed_users('somebody-not-driver')
+def driver_not_allowed_hello(message):
+    message.reply('Driver not allowed!')


### PR DESCRIPTION
- add `test_plugins` in `tests\behavior_tests`
- the  `driver_allowed_hello` handler respond to `"allowed_driver"` message sent by driver bot
- the `driver_not_allowed_hello` handler denies `"not_allowed_driver"` message sent by driver bot